### PR TITLE
Fix typo in recipe listing page

### DIFF
--- a/pages/All_Recipes.py
+++ b/pages/All_Recipes.py
@@ -5,7 +5,7 @@ from helper_functions import render_recipe, merge_ingredients_into_recipes
 
 
 
-# path to recipies
+# path to recipes
 RECIPE_FILE = "recipes.json"
 
 # paget setup
@@ -26,7 +26,7 @@ recipes = merge_ingredients_into_recipes(recipes)
 
 
 if not recipes:
-    st.info("No recipies currently exists")
+    st.info("No recipes currently exist")
     st.stop()
     
 # Helper file, save updated lists back to file


### PR DESCRIPTION
## Summary
- fix spelling of "recipes" in path comment and empty-state message on recipe list page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e4fb2107c8324af73b0865c1bd5ac