### PR TITLE
Display SKUID for recipes

### DIFF
--- a/helper_functions.py
+++ b/helper_functions.py
@@ -120,6 +120,7 @@ def render_recipe(recipe, index, recipes, save_recipes):
         st.markdown(f"**备注**: {recipe['备注']}")
     with col2:
         st.markdown(f"**编号**: {recipe['编号']}")
+        st.markdown(f"**SKUID**: {recipe.get('SKUID') or 'N/A'}")
         st.markdown(f"**创建时间**: {recipe['创建时间']}")
         st.markdown(f"**修改时间**: {recipe['修改时间']}")
 
@@ -254,8 +255,11 @@ def save_uploaded_file(uploaded_file, filename_hint=None):
 
 def display_recipe(recipe):
     key_suffix = recipe["编号"]
-    with st.expander(f"{recipe['中文名']} / {recipe['英文名']} — 售价: ¥{recipe['售价']}"):
+    skuid = recipe.get("SKUID") or "N/A"
+    label = f"{recipe['中文名']} / {recipe['英文名']} — SKUID: {skuid} — 售价: ¥{recipe['售价']}"
+    with st.expander(label):
         st.markdown(f"**编号**: {recipe['编号']}")
+        st.markdown(f"**SKUID**: {skuid}")
         st.markdown(f"**总成本**: ¥{recipe['总成本']}")
         st.markdown(f"**成本百分比**: {recipe['成本百分比']}%")
         st.markdown(f"**创建时间**: {recipe['创建时间']}")

--- a/pages/All_Recipes.py
+++ b/pages/All_Recipes.py
@@ -49,13 +49,17 @@ if selected_category == "全部":
     for cat_name, group in grouped.items():
         st.subheader(f"📂 分类: {cat_name}")
         for index, recipe in enumerate(group):
-            with st.expander(f"{recipe['编号']} {recipe['中文名']} / {recipe['英文名']} — 售价: ¥{recipe['售价']}"):
+            skuid = recipe.get("SKUID") or "N/A"
+            label = f"{recipe['编号']} {recipe['中文名']} / {recipe['英文名']} — SKUID: {skuid} — 售价: ¥{recipe['售价']}"
+            with st.expander(label):
                 render_recipe(recipe, index, recipes, save_recipes)
 
 else:
     # Show only selected category
     filtered_recipes = [r for r in recipes if r.get("分类") == selected_category]
-    for index, recipe in enumerate(filtered_recipes):  
-        with st.expander(f"{recipe['中文名']} / {recipe['英文名']} — 售价: ¥{recipe['售价']}"):
+    for index, recipe in enumerate(filtered_recipes):
+        skuid = recipe.get("SKUID") or "N/A"
+        label = f"{recipe['编号']} {recipe['中文名']} / {recipe['英文名']} — SKUID: {skuid} — 售价: ¥{recipe['售价']}"
+        with st.expander(label):
             render_recipe(recipe, index, recipes, save_recipes)
             


### PR DESCRIPTION
## Summary
- Show SKUID in All_Recipes expanders so users can see identifiers while browsing
- Render SKUID alongside recipe numbers and timestamps
- Include SKUID in generic recipe display helper with N/A placeholder

## Testing
- `pytest -q`
- `python -m py_compile pages/All_Recipes.py helper_functions.py`


------
https://chatgpt.com/codex/tasks/task_e_688e51ffa2508324b23693956f4a62d4